### PR TITLE
Fixing Issue #126, Duplicate Sapphire Mark and no Sapphire Broam

### DIFF
--- a/playtest/module.json
+++ b/playtest/module.json
@@ -1,7 +1,7 @@
 {
     "id": "cosmere-rpg-playtest",
     "title": "Cosmere RPG - Playtest Materials",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "compatibility": {
         "minimum": "12",
         "verified": "12"
@@ -96,5 +96,5 @@
     ],
     "url": "https://github.com/stanavdb/cosmere-rpg-worlds",
     "manifest": "https://raw.githubusercontent.com/stanavdb/cosmere-rpg-worlds/main/playtest/module.json",
-    "download": "https://github.com/stanavdb/cosmere-rpg-worlds/releases/download/playtest-0.1.1/cosmere-rpg-playtest-0.1.1.zip"
+    "download": "https://github.com/stanavdb/cosmere-rpg-worlds/releases/download/playtest-0.1.2/cosmere-rpg-playtest-0.1.2.zip"
 }


### PR DESCRIPTION
(Copying form from other repository as there is no template here)

<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixing a compendium issue reported in the other repository #126. Two loot items with duplicate names, but different values. Corrected the names by updating one to 'Sapphire Broam'-

**Related Issue**  
Closes [#126](https://github.com/stanavdb/cosmere-rpg/issues/126)

**How Has This Been Tested?**  
Navigate to the compendium, Items, Loot. Current public version has two items named the same with differing icons and values.

**Screenshots (if applicable)**
Prior:
![image](https://github.com/user-attachments/assets/6b05394b-4622-4392-84be-d6e4cbba2177)

Updated:  
![image](https://github.com/user-attachments/assets/130fddeb-1e1e-4725-86a0-b3478244a1e0)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: v12.331.

**Additional context**  
As the actual compendium is not contained within this repository, and I could not find it in the other I have attached a zip that can simply be added as a new release before merging this pull request. Tested in my own [fork](https://github.com/RostCS/cosmere-rpg-worlds)

[cosmere-rpg-playtest-0.1.2.zip](https://github.com/user-attachments/files/17551648/cosmere-rpg-playtest-0.1.2.zip)
